### PR TITLE
meta-summit-radio: conf: fix LAYERSERIES_COMPAT

### DIFF
--- a/meta-summit-radio/conf/layer.conf
+++ b/meta-summit-radio/conf/layer.conf
@@ -8,7 +8,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "summit-radio"
 BBFILE_PATTERN_summit-radio = "^${LAYERDIR}/"
 BBFILE_PRIORITY_summit-radio = "8"
-LAYERSERIES_COMPAT_meta-laird-cp = "kirkstone"
+
+LAYERSERIES_COMPAT_summit-radio = "honister kirkstone langdale mickledore"
 
 BB_DANGLINGAPPENDS_WARNONLY = "1"
 


### PR DESCRIPTION
The layer name is different in the current version. Also add all
officially supported versions.

This fixes: commit 09d501 meta-summit-radio: Add LAYERSERIES_COMPAT

Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
